### PR TITLE
Better buildSrc support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,10 +60,8 @@ kotlin {
     target {
         compilations.all {
             kotlinOptions {
-                useIR = true
                 jvmTarget = "1.8"
                 freeCompilerArgs = freeCompilerArgs + listOf(
-                    "-Xuse-ir",
                     "-Xjvm-default=all",
                     "-Xinline-classes",
                     "-Xopt-in=kotlin.Experimental"

--- a/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
+++ b/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * A plugin that generates and sets the version code and version name for an Android app using the latest git tag.
  */
 @Suppress("UnstableApiUsage")
-internal class AppVersioningPlugin : Plugin<Project> {
+class AppVersioningPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val agpVersion = VersionNumber.parse(ANDROID_GRADLE_PLUGIN_VERSION)
         check(agpVersion >= VersionNumber.parse(MIN_AGP_VERSION)) {


### PR DESCRIPTION
Fixes #5.

- Disabled IR to support applying the plugin within `buildSrc` using `kotlin-dsl`.
- Exposed `AppVersioningPlugin` as public API to support applying plugin using `type` instead of plugin id.

```kotlin
with(project) {
    pluginManager.apply(AppVersioningPlugin::class.java)
    plugins.withType<AppVersioningPlugin> {
        extensions.configure<AppVersioningExtension> {
            overrideVersionCode { _, _ ->
                Instant.now().epochSecond.toInt()
            }
            overrideVersionName { gitTag, _ ->
                "${gitTag.rawTagName} (${gitTag.commitHash})"
            }
        }
    }
}
```