### PR TITLE
Add VariantInfo lambda parameter

### DIFF
--- a/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningExtension.kt
+++ b/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningExtension.kt
@@ -35,9 +35,10 @@ open class AppVersioningExtension internal constructor(objects: ObjectFactory) {
     )
 
     /**
-     * Provides a custom rule for generating versionCode by implementing a [GitTag], [ProviderFactory] -> Int lambda.
+     * Provides a custom rule for generating versionCode by implementing a [GitTag], [ProviderFactory], [VariantInfo] -> Int lambda.
      * [GitTag] is generated from latest git tag lazily by the plugin during task execution.
      * [ProviderFactory] can be used for fetching environment variables, Gradle and system properties.
+     * [VariantInfo] can be used to customize version code based on the build variants (product flavors and build types).
      *
      * By default the plugin attempts to generate the versionCode by converting a SemVer compliant tag to an integer
      * using positional notation: versionCode = MAJOR * 10000 + MINOR * 100 + PATCH
@@ -60,9 +61,10 @@ open class AppVersioningExtension internal constructor(objects: ObjectFactory) {
     }
 
     /**
-     * Provides a custom rule for generating versionName by implementing a [GitTag], [ProviderFactory] -> String lambda.
+     * Provides a custom rule for generating versionName by implementing a [GitTag], [ProviderFactory], [VariantInfo] -> String lambda.
      * [GitTag] is generated from latest git tag lazily by the plugin during task execution.
      * [ProviderFactory] can be used for fetching environment variables, Gradle and system properties.
+     * [VariantInfo] can be used to customize version name based on the build variants (product flavors and build types).
      *
      * This is useful if you want to fully customize how the versionName is generated.
      * If not specified, versionName will be the name of the latest git tag.
@@ -105,5 +107,5 @@ open class AppVersioningExtension internal constructor(objects: ObjectFactory) {
     }
 }
 
-internal typealias VersionCodeCustomizer = (GitTag, ProviderFactory) -> Int
-internal typealias VersionNameCustomizer = (GitTag, ProviderFactory) -> String
+internal typealias VersionCodeCustomizer = (GitTag, ProviderFactory, VariantInfo) -> Int
+internal typealias VersionNameCustomizer = (GitTag, ProviderFactory, VariantInfo) -> String

--- a/src/main/kotlin/io/github/reactivecircus/appversioning/VariantInfo.kt
+++ b/src/main/kotlin/io/github/reactivecircus/appversioning/VariantInfo.kt
@@ -1,0 +1,13 @@
+package io.github.reactivecircus.appversioning
+
+import org.gradle.language.nativeplatform.internal.BuildType
+import java.io.Serializable
+
+class VariantInfo(
+    val buildType: String?,
+    val flavorName: String,
+    val variantName: String
+) : Serializable {
+    val isDebugBuild: Boolean get() = buildType == BuildType.DEBUG.name
+    val isReleaseBuild: Boolean get() = buildType == BuildType.RELEASE.name
+}

--- a/src/test/kotlin/io/github/reactivecircus/appversioning/VariantInfoTest.kt
+++ b/src/test/kotlin/io/github/reactivecircus/appversioning/VariantInfoTest.kt
@@ -1,0 +1,77 @@
+package io.github.reactivecircus.appversioning
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class VariantInfoTest {
+
+    @Test
+    fun `VariantInfo#isDebugBuild returns true when builtType is 'debug'`() {
+        assertThat(
+            VariantInfo(
+                buildType = "debug",
+                flavorName = "",
+                variantName = "debug"
+            ).isDebugBuild
+        ).isTrue()
+
+        assertThat(
+            VariantInfo(
+                buildType = "release",
+                flavorName = "",
+                variantName = "release"
+            ).isDebugBuild
+        ).isFalse()
+
+        assertThat(
+            VariantInfo(
+                buildType = null,
+                flavorName = "",
+                variantName = ""
+            ).isDebugBuild
+        ).isFalse()
+
+        assertThat(
+            VariantInfo(
+                buildType = "DEBUG",
+                flavorName = "prod",
+                variantName = "prodDebug"
+            ).isDebugBuild
+        ).isFalse()
+    }
+
+    @Test
+    fun `VariantInfo#isReleaseBuild returns true when builtType is 'release'`() {
+        assertThat(
+            VariantInfo(
+                buildType = "release",
+                flavorName = "",
+                variantName = "release"
+            ).isReleaseBuild
+        ).isTrue()
+
+        assertThat(
+            VariantInfo(
+                buildType = "debug",
+                flavorName = "",
+                variantName = "debug"
+            ).isReleaseBuild
+        ).isFalse()
+
+        assertThat(
+            VariantInfo(
+                buildType = null,
+                flavorName = "",
+                variantName = ""
+            ).isReleaseBuild
+        ).isFalse()
+
+        assertThat(
+            VariantInfo(
+                buildType = "RELEASE",
+                flavorName = "prod",
+                variantName = "prodRelease"
+            ).isDebugBuild
+        ).isFalse()
+    }
+}


### PR DESCRIPTION
Add `VariantInfo` lambda parameter to `overrideVersionCode` and `overrideVersionName` to support customizing `versionCode` and `versionName` based on build variants.