### PR TITLE
Support setting gitRootDirectory explicitly when root Gradle project is not the git root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,20 @@ appVersioning {
 }
 ```
 
+### Custom git root directory
+
+The plugin assumes the root Gradle project is the git root directory that contains `.git`. If your root Gradle project is not your git root, you can specify it explicitly:
+
+```kt
+appVersioning {
+    /**
+     * Git root directory used for fetching git tags.
+     * Use this to explicitly set the git root directory when the root Gradle project is not the git root directory.
+     */
+    gitRootDirectory.set(rootProject.file("../")) // if the .git directory is in the root Gradle project's parent directory.
+}
+```
+
 ## App versioning on CI
 
 For performance reason many CI providers only fetch a single commit by default when checking out the repository. For **app-versioning** to work we need to make sure Git tags are also fetched. Here's an example for doing this with [GutHub Actions](https://github.com/actions/checkout):

--- a/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningExtension.kt
+++ b/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningExtension.kt
@@ -35,6 +35,12 @@ open class AppVersioningExtension internal constructor(objects: ObjectFactory) {
     )
 
     /**
+     * Git root directory used for fetching git tags.
+     * Use this to explicitly set the git root directory when the root Gradle project is not the git root directory.
+     */
+    val gitRootDirectory = objects.directoryProperty().convention(null)
+
+    /**
      * Custom glob pattern for matching git tags.
      */
     val tagFilter = objects.property<String>().convention(null)

--- a/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
+++ b/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
@@ -73,7 +73,13 @@ class AppVersioningPlugin : Plugin<Project> {
         group = APP_VERSIONING_TASK_GROUP
         description = "${GenerateAppVersionInfo.TASK_DESCRIPTION_PREFIX} for the ${variant.name} variant."
 
-        gitRefsDirectory.set(project.rootProject.file(GIT_REFS_DIRECTORY).let { if (it.exists()) it else null })
+        gitRefsDirectory.set(project.rootProject.file(GIT_REFS_DIRECTORY).let { rootGradleProject ->
+            if (rootGradleProject.exists()) rootGradleProject else {
+                extension.gitRootDirectory.takeIf { it.isPresent }?.let { gitRootDirectory ->
+                    gitRootDirectory.asFile.orNull?.resolve(GIT_REFS_DIRECTORY)?.takeIf { it.exists() }
+                }
+            }
+        })
         rootProjectDirectory.set(project.rootProject.rootDir)
         rootProjectDisplayName.set(project.rootProject.displayName)
         fetchTagsWhenNoneExistsLocally.set(extension.fetchTagsWhenNoneExistsLocally)

--- a/src/main/kotlin/io/github/reactivecircus/appversioning/tasks/GenerateAppVersionInfo.kt
+++ b/src/main/kotlin/io/github/reactivecircus/appversioning/tasks/GenerateAppVersionInfo.kt
@@ -146,7 +146,7 @@ abstract class GenerateAppVersionInfoWorkAction @Inject constructor(
         val variantInfo = parameters.variantInfo
 
         check(gitRefsDirectory.isPresent) {
-            "Android App Versioning Gradle Plugin works with git tags but ${rootProjectDisplayName.get()} is not a valid git repository."
+            "Android App Versioning Gradle Plugin works with git tags but ${rootProjectDisplayName.get()} is not a git root directory, and a valid gitRootDirectory is not provided."
         }
 
         val gitClient = GitClient.open(rootProjectDirectory.get().asFile)


### PR DESCRIPTION
Fixes #12.

If the root Gradle project is not the git root:

```
myproject/
  .gits/
  android/ <- root Gradle project
    app/
    library/
```

The git root directory needs to be specified explicitly:

```kotlin
appVersioning {
    gitRootDirectory.set(rootProject.file("../"))
}
```