### PR TITLE
Fix configuration cache issue

### DIFF
--- a/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
+++ b/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
@@ -51,8 +51,8 @@ class AppVersioningPlugin : Plugin<Project> {
                         extension = appVersioningExtension
                     )
 
-                    val generatedVersionCode = generateAppVersionInfo.map { it.versionCodeFile.asFile.get().readText().trim().toInt() }
-                    val generatedVersionName = generateAppVersionInfo.map { it.versionNameFile.asFile.get().readText().trim() }
+                    val generatedVersionCode = generateAppVersionInfo.flatMap { it.versionCodeFile.map { it.asFile.readText().trim().toInt() } }
+                    val generatedVersionName = generateAppVersionInfo.flatMap { it.versionNameFile.map { it.asFile.readText().trim() } }
 
                     project.registerPrintAppVersionInfoTask(variantName = variant.name)
 


### PR DESCRIPTION
Fixes #24
Fixes #26

Configuration cache issue can be reproduced with the following steps:
1. `./gradlew clean`
2. `rm -rf .gradle/configuration-cache/`
3. `./gradlew assembleDebug`

This will fail with something like:
```
../../build/outputs/app_versioning/debug/version_code.txt (No such file or directory)
```