### PR TITLE
Remove dependency on `com.android.tools:common`, stop supporting AGP 7.x or lower.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       AGP_VERSION: ${{ matrix.agp-version }}
     strategy:
       matrix:
-        agp-version: [ 7.3.1, 7.4.2, 8.0.2, 8.1.4, 8.2.2, 8.3.2, 8.4.2, 8.5.2, 8.6.1, 8.7.3, 8.8.2, 8.9.2, 8.10.1, 8.11.0-alpha10, 8.12.0-alpha02 ]
+        agp-version: [ 8.0.2, 8.1.4, 8.2.2, 8.3.2, 8.4.2, 8.5.2, 8.6.1, 8.7.3, 8.8.2, 8.9.2, 8.10.1, 8.11.0-alpha10, 8.12.0-alpha02 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-No changes yet.
+### Changed
+- Minimum Android Gradle Plugin version is now **8.0.0**.
+- Remove `compileOnly` dependency on `com.android.tools:common` to support future version of AGP.
 
 ## 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ This [blogpost](https://dev.to/ychescale9/git-based-android-app-versioning-with-
 
 ## Android Gradle Plugin version compatibility
 
-The minimum version of Android Gradle Plugin required is **7.0.0-beta04**.
+The minimum version of Android Gradle Plugin required is **8.0.0**.
+
+Version `1.4.0` of the plugin is the final version that's compatible with AGP **7.x** and below.
 
 Version `0.4.0` of the plugin is the final version that's compatible with AGP **4.0** and **4.1**.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,11 +86,10 @@ val test by tasks.getting(Test::class) {
 val fixtureAgpVersion: Provider<String> = providers
     .environmentVariable("AGP_VERSION")
     .orElse(providers.gradleProperty("AGP_VERSION"))
-    .orElse(libs.versions.agp.asProvider())
+    .orElse(libs.versions.agp)
 
 dependencies {
     compileOnly(libs.agp.build)
-    compileOnly(libs.agp.common)
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.testParameterInjector)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 kotlin = "2.1.20"
 binaryCompabilityValidator = "0.15.1"
 agp = "8.10.1"
-agp-common = "31.10.1"
 detekt = "1.23.7"
 mavenPublish = "0.31.0"
 junit = "4.13.2"
@@ -14,7 +13,6 @@ toolchainsResolver = "0.10.0"
 plugin-detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 
 agp-build = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-agp-common = { module = "com.android.tools:common", version.ref = "agp-common" }
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 testParameterInjector = { group = "com.google.testparameterinjector", name = "test-parameter-injector", version.ref = "testParameterInjector" }

--- a/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
+++ b/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
@@ -12,7 +12,6 @@ import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
 import org.gradle.language.nativeplatform.internal.BuildType
 import java.io.File
-import java.lang.module.ModuleDescriptor.Version
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -28,17 +27,6 @@ class AppVersioningPlugin : Plugin<Project> {
         project.plugins.withType<AppPlugin> {
             androidAppPluginApplied.set(true)
             val extension = project.extensions.getByType<ApplicationAndroidComponentsExtension>()
-
-            val gradleVersion = Version.parse(project.gradle.gradleVersion)
-            check(gradleVersion >= Version.parse(MIN_GRADLE_VERSION)) {
-                "Android App Versioning Gradle Plugin requires Gradle $MIN_GRADLE_VERSION or later. Detected Gradle version is $gradleVersion."
-            }
-
-            val agpVersion = Version.parse(extension.pluginVersion.version)
-            check(agpVersion >= Version.parse(MIN_AGP_VERSION)) {
-                "Android App Versioning Gradle Plugin requires Android Gradle Plugin $MIN_AGP_VERSION or later. Detected AGP version is $agpVersion."
-            }
-
             extension.onVariants(selector = extension.selector().all()) { variant ->
                 if (pluginDisabled.get()) return@onVariants
                 if (!appVersioningExtension.enabled.get()) {
@@ -159,10 +147,7 @@ class AppVersioningPlugin : Plugin<Project> {
         return replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
     }
 
-    companion object {
-        private const val MIN_GRADLE_VERSION = "6.8"
-        private const val MIN_AGP_VERSION = "7.0.0-beta04"
-    }
+    companion object
 }
 
 private const val APP_VERSIONING_TASK_GROUP = "versioning"

--- a/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
+++ b/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt
@@ -1,6 +1,5 @@
 package io.github.reactivecircus.appversioning
 
-import com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
 import com.android.build.gradle.AppPlugin
@@ -23,20 +22,23 @@ import java.util.concurrent.atomic.AtomicBoolean
 class AppVersioningPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
-        val gradleVersion = Version.parse(project.gradle.gradleVersion)
-        check(gradleVersion >= Version.parse(MIN_GRADLE_VERSION)) {
-            "Android App Versioning Gradle Plugin requires Gradle $MIN_GRADLE_VERSION or later. Detected Gradle version is $gradleVersion."
-        }
-        val agpVersion = Version.parse(ANDROID_GRADLE_PLUGIN_VERSION)
-        check(agpVersion >= Version.parse(MIN_AGP_VERSION)) {
-            "Android App Versioning Gradle Plugin requires Android Gradle Plugin $MIN_AGP_VERSION or later. Detected AGP version is $agpVersion."
-        }
         val androidAppPluginApplied = AtomicBoolean(false)
         val pluginDisabled = AtomicBoolean(false)
         val appVersioningExtension = project.extensions.create("appVersioning", AppVersioningExtension::class.java)
         project.plugins.withType<AppPlugin> {
             androidAppPluginApplied.set(true)
             val extension = project.extensions.getByType<ApplicationAndroidComponentsExtension>()
+
+            val gradleVersion = Version.parse(project.gradle.gradleVersion)
+            check(gradleVersion >= Version.parse(MIN_GRADLE_VERSION)) {
+                "Android App Versioning Gradle Plugin requires Gradle $MIN_GRADLE_VERSION or later. Detected Gradle version is $gradleVersion."
+            }
+
+            val agpVersion = Version.parse(extension.pluginVersion.version)
+            check(agpVersion >= Version.parse(MIN_AGP_VERSION)) {
+                "Android App Versioning Gradle Plugin requires Android Gradle Plugin $MIN_AGP_VERSION or later. Detected AGP version is $agpVersion."
+            }
+
             extension.onVariants(selector = extension.selector().all()) { variant ->
                 if (pluginDisabled.get()) return@onVariants
                 if (!appVersioningExtension.enabled.get()) {


### PR DESCRIPTION
Remove AGP version check using  `com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION` from `com.android.tools:common` which isn't part of the official AGP APIs.

Supported AGP version is now 8.0+.